### PR TITLE
Fixed bug with status filter.

### DIFF
--- a/PerplexMail/Constants.cs
+++ b/PerplexMail/Constants.cs
@@ -250,9 +250,9 @@ ON
 WHERE 
 	(@status = -1)
 OR 
-	(@status = 0 AND v.[viewed] IS NULL AND c.[clicked] IS NULL AND w.[webversion] IS NULL and result.[exception] IS NULL) 
+	(@status = 0 AND v.[viewed] IS NULL AND c.[clicked] IS NULL AND w.[webversion] IS NULL AND ISNULL(result.[exception],'') = '') 
 OR 
-	(@status = 1 AND result.[exception] IS NOT NULL) 
+	(@status = 1 AND ISNULL(result.[exception],'') <> '') 
 OR 
 	(@status = 2 AND (v.[viewed] IS NOT NULL OR c.[clicked] IS NOT NULL OR w.[webversion] IS NOT NULL)) 
 OR 


### PR DESCRIPTION
@PerplexWouter 

Fix for statistics status filter.

Original code was expecting a "no error" record to have a null value for exception, however, it is actually an empty string.

Updated WHERE clause for statuses of "Sent" and "Error" to correctly handle both NULL and empty string values.